### PR TITLE
set "which" property on events

### DIFF
--- a/jquery.autotype.js
+++ b/jquery.autotype.js
@@ -177,9 +177,9 @@
             };
 
             // build out 3 event instances for all the steps of a key entry
-            var keyDownEvent = $.extend($.Event(), evnt, {type:'keydown', keyCode: code.keyCode, charCode: 0});
-            var keyPressEvent = $.extend($.Event(), evnt, {type:'keypress', keyCode: 0, charCode: code.charCode});
-            var keyUpEvent = $.extend($.Event(), evnt, {type:'keyup', keyCode: code.keyCode, charCode: 0});
+            var keyDownEvent = $.extend($.Event(), evnt, {type:'keydown', keyCode: code.keyCode, charCode: 0, which: code.keyCode});
+            var keyPressEvent = $.extend($.Event(), evnt, {type:'keypress', keyCode: 0, charCode: code.charCode, which: code.charCode || code.keyCode});
+            var keyUpEvent = $.extend($.Event(), evnt, {type:'keyup', keyCode: code.keyCode, charCode: 0, which: code.keyCode});
         
             // go ahead and trigger the first 2 (down and press)         
             // a keyup of a modifier shouldn't also re-trigger a keydown       


### PR DESCRIPTION
most jQuery examples online test e.which. i'm not sure this fix goes far enough to make sure it's uniform but seems to work okay.

useful: http://www.asquare.net/javascript/tests/KeyCode.html
